### PR TITLE
Fix BPUP returning non-status messages

### DIFF
--- a/bond_api/bpup.py
+++ b/bond_api/bpup.py
@@ -49,7 +49,7 @@ class BPUPSubscriptions:
         device_id = topic[1]
 
         for callback in self._callbacks.get(device_id, []):
-            callback(json_msg["b"])
+            callback(json_msg)
 
 
 class BPUProtocol(asyncio.Protocol):

--- a/tests/test_bpup.py
+++ b/tests/test_bpup.py
@@ -140,12 +140,16 @@ async def test_protocol_subscriptions(transport, caplog):
     )
 
     assert last_msg == {
-        "_": "690b6aff",
-        "breeze": [0, 50, 50],
-        "power": 1,
-        "speed": 1,
-        "timer": 0,
-    }
+        "t":"devices/1/state",
+        "s":200,
+        "b":{
+            "power":1,
+            "speed":1,
+            "timer":0,
+            "breeze":[0,50,50],
+            "_":"690b6aff"
+            }
+        }
 
     bpup_protocol.datagram_received(
         b'{"t":"devices/1/state","s":200,"b":{"power":1,"speed":1,"timer":0,"breeze":[0,50,50],"_":"690b6aff"}}\n',
@@ -153,12 +157,16 @@ async def test_protocol_subscriptions(transport, caplog):
     )
     # 500 error should not trigger a new message
     assert last_msg == {
-        "_": "690b6aff",
-        "breeze": [0, 50, 50],
-        "power": 1,
-        "speed": 1,
-        "timer": 0,
-    }
+        "t":"devices/1/state",
+        "s":200,
+        "b":{
+            "power":1,
+            "speed":1,
+            "timer":0,
+            "breeze":[0,50,50],
+            "_":"690b6aff"
+            }
+        }
 
     last_msg = {}
     bpup_subscriptions.unsubscribe("1", _on_new_message)


### PR DESCRIPTION
## The issue

BPUP doesn't only return device status messages. It returns all responses to HTTP requests as well.

I.e.:
```bash
    477750:         TS_HTTP:345  : INFO : HTTP PUT /v2/devices/73c3c59b089a795d/actions/Open
    477791: [06000026c8f33dfa HTTP-STA   PUT     0 D   /devices/73c3c59b089a795d/actions/Open] {}
    477805: BBridge_Action_API:1133 : INFO : bbridge_action_handle_put Open() tx via script
    477916: BondScript_RMS35:265  : USER : mfg=1, addr=00685410 chanmap=0001 command=Open, counter=1
    477924: BondScript_Lua_API:102  : INFO : bondscript_tx: freq 433922 BPS 40000 reps 4 len 2946
    477979: [05000038aef5de1d Bond-AWS   GET   200 Ub  /devices/73c3c59b089a795d/state] {"B":"ZPEA77117","d":0,"v":"v3.2.4-alpha","i":"05000038aef5de1d","f":100,"s":200,"m":0,"x":"bond","b":{"open":1,"position":0,"counter1":0,"counter2":0,"_":"109f5bd9","__":"109f5bd9"}}
    477991: [05000038aef5de1d Bond-CLI   GET   200 Ub  /devices/73c3c59b089a795d/state] {"B":"ZPEA77117","d":0,"v":"v3.2.4-alpha","t":"devices/73c3c59b089a795d/state","i":"05000038aef5de1d","f":100,"s":200,"m":0,"x":"bond","b":{"open":1,"position":0,"counter1":0,"counter2":0,"_":"109f5bd9","__":"109f5bd9"}}
    478032: [06000026c8f33dfa HTTP-STA   PUT   200 U   /devices/73c3c59b089a795d/actions/Open] {"_":"00000204","__":"00000204"}
```

This was calling the `notify` function of `bpup.py` two times, so it was first returning `{"open":1,"position":0,"counter1":0,"counter2":0,"_":"109f5bd9","__":"109f5bd9"}` and then `{"_":"00000204","__":"00000204"}`

## Proposed change
**[breaking change]**
instead of returning just the body of the message (`b`), this function should return the whole message, then the user of this lib can filter the messages by topic.