### PR TITLE
Add Switch and Heater device types

### DIFF
--- a/bond_async/device_type.py
+++ b/bond_async/device_type.py
@@ -12,6 +12,8 @@ class DeviceType:
     BIDET = "BD"
     LIGHT = "LT"
     GENERIC_DEVICE = "GX"
+    SWITCH = "SW"
+    HEATER = "HT"
 
     @staticmethod
     def is_fan(device_type: str) -> bool:
@@ -52,3 +54,13 @@ class DeviceType:
     def is_generic(device_type: str) -> bool:
         """Checks if specified device type is generic."""
         return device_type == DeviceType.GENERIC_DEVICE
+
+    @staticmethod
+    def is_switch(device_type: str) -> bool:
+        """Checks if specified device type is switch."""
+        return device_type == DeviceType.SWITCH
+
+    @staticmethod
+    def is_heater(device_type: str) -> bool:
+        """Checks if specified device type is heater."""
+        return device_type == DeviceType.HEATER

--- a/tests/test_device_type.py
+++ b/tests/test_device_type.py
@@ -28,3 +28,9 @@ def test_compare_device_types():
 
     assert DeviceType.LIGHT == "LT"
     assert DeviceType.is_light("LT")
+
+    assert DeviceType.SWITCH == "SW"
+    assert DeviceType.is_switch("SW")
+
+    assert DeviceType.HEATER == "HT"
+    assert DeviceType.is_heater("HT")


### PR DESCRIPTION
## Summary

- Add `SWITCH` (SW) device type for generic switch devices
- Add `HEATER` (HT) device type for heater devices
- Add `is_switch()` and `is_heater()` helper methods
- Add corresponding test cases

These device types align bond-async with bond-core's supported device types.

## Test plan

- [x] Verified new constants and methods work correctly
- [x] Run `pytest tests/test_device_type.py -v` to validate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)