### PR TITLE
Update CI to supported Python versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -39,4 +39,4 @@ jobs:
       run: |
         pytest --cov-report term-missing --cov-report=xml --cov=bond_async
     - name: Upload codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-flake8==3.8.3
+flake8>=6.0.0
 pytest>=5.4.3
 pytest-asyncio>=0.14.0
 pytest-cov>=2.10.0


### PR DESCRIPTION
## Summary

- Remove Python 3.7 and 3.8 (both reached end-of-life)
- Add Python 3.11 and 3.12
- Update `actions/checkout` from v2 to v4
- Update `actions/setup-python` from v2 to v5
- Update `codecov/codecov-action` from v2 to v4
- Update flake8 from 3.8.3 to >=6.0.0 (required for Python 3.12 compatibility)

## Context

CI was failing because:
1. Python 3.7 is no longer available on GitHub Actions runners (EOL June 2023)
2. flake8 3.8.3 is incompatible with Python 3.12 due to importlib.metadata API changes

## Test plan

- [ ] CI passes on all Python versions (3.9, 3.10, 3.11, 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)